### PR TITLE
Fix(Composer): Lower silverstripe/framework to ~3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require"    : {
-        "silverstripe/framework"        : "~3.3",
+        "silverstripe/framework"        : "~3.1",
         "milkyway-multimedia/ss-mwm-env": "~0.3"
     },
     "suggest"    : {


### PR DESCRIPTION
Lower silverstripe/framework to ~3.1 so the module can work on 3.1 builds.

Any reason for the ~3.3 requirement? Looking to use the SaveAllButton for a 3.1 project.
